### PR TITLE
fix(eslint-config): default import for react-internal base config

### DIFF
--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -4,7 +4,7 @@ import tseslint from "typescript-eslint";
 import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginReact from "eslint-plugin-react";
 import globals from "globals";
-import { config as baseConfig } from "./base.js";
+import baseConfig from "./base.js";
 
 /**
  * A custom ESLint configuration for libraries that use React.


### PR DESCRIPTION
## Summary
- utilise l'import par défaut pour récupérer la configuration de base

## Testing
- `node -e "import('./packages/eslint-config/react-internal.js').then(m=>console.log('configs',m.config.length))"`
- `yarn lint:packages` *(échoue : Error while loading rule '@typescript-eslint/await-thenable')*


------
https://chatgpt.com/codex/tasks/task_e_68bc3793fd708324919004a5b6d7f941