### PR TITLE
chore(eslint): resolve tsconfig paths with fileURLToPath

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,8 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import makeNextConfig from "@packages/eslint-config/next-js";
+
+const tsconfigRootDir = path.dirname(fileURLToPath(new URL("./package.json", import.meta.url)));
 
 export default [
     { ignores: ["apps/web/next-env.d.ts", "apps/web/next.config.ts"] },
@@ -15,7 +19,7 @@ export default [
                     "./packages/types/tsconfig.json",
                     "./packages/ui/tsconfig.json",
                 ],
-                tsconfigRootDir: new URL("./", import.meta.url).pathname,
+                tsconfigRootDir,
             },
         },
     },

--- a/packages/domain/eslint.config.js
+++ b/packages/domain/eslint.config.js
@@ -1,11 +1,15 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import baseConfig from "../eslint.config.mjs";
+
+const tsconfigRootDir = path.dirname(fileURLToPath(new URL("./package.json", import.meta.url)));
 
 export default [
     {
         languageOptions: {
             parserOptions: {
                 project: ["./tsconfig.json"],
-                tsconfigRootDir: new URL(".", import.meta.url).pathname,
+                tsconfigRootDir,
             },
         },
     },

--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -1,7 +1,10 @@
 // packages/eslint-config/next.js
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import nextPlugin from "@next/eslint-plugin-next";
 import base from "./base.js";
 
+const tsconfigRootDir = path.dirname(fileURLToPath(new URL("../../package.json", import.meta.url)));
 const nextRules = nextPlugin.configs["core-web-vitals"].rules;
 
 export default function makeNextConfig({
@@ -18,7 +21,7 @@ export default function makeNextConfig({
             languageOptions: {
                 parserOptions: {
                     project: [webProject],
-                    tsconfigRootDir: new URL("../../", import.meta.url).pathname, // racine monorepo
+                    tsconfigRootDir, // racine monorepo
                 },
             },
             settings: { next: { rootDir: ["apps/web/"] } },

--- a/packages/services/eslint.config.js
+++ b/packages/services/eslint.config.js
@@ -1,11 +1,15 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import baseConfig from "../eslint.config.mjs";
+
+const tsconfigRootDir = path.dirname(fileURLToPath(new URL("./package.json", import.meta.url)));
 
 export default [
     {
         languageOptions: {
             parserOptions: {
                 project: ["./tsconfig.json"],
-                tsconfigRootDir: new URL(".", import.meta.url).pathname,
+                tsconfigRootDir,
             },
         },
     },

--- a/packages/types/eslint.config.js
+++ b/packages/types/eslint.config.js
@@ -1,11 +1,15 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import baseConfig from "../eslint.config.mjs";
+
+const tsconfigRootDir = path.dirname(fileURLToPath(new URL("./package.json", import.meta.url)));
 
 export default [
     {
         languageOptions: {
             parserOptions: {
                 project: ["./tsconfig.json"],
-                tsconfigRootDir: new URL(".", import.meta.url).pathname,
+                tsconfigRootDir,
             },
         },
     },

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -1,11 +1,15 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import baseConfig from "../eslint.config.mjs";
+
+const tsconfigRootDir = path.dirname(fileURLToPath(new URL("./package.json", import.meta.url)));
 
 export default [
     {
         languageOptions: {
             parserOptions: {
                 project: ["./tsconfig.json"],
-                tsconfigRootDir: new URL(".", import.meta.url).pathname,
+                tsconfigRootDir,
             },
         },
     },


### PR DESCRIPTION
## Summary
- use fileURLToPath and path to compute tsconfigRootDir in ESLint configs

## Testing
- `yarn lint` *(fails: Error while loading rule '@typescript-eslint/await-thenable': You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a3183388324b77716f3a0cab9a3