### PR TITLE
chore(eslint): différencier configs JS et TS

### DIFF
--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -13,8 +13,17 @@ export default [
     // Base JS
     js.configs.recommended,
 
+    // JS sans infos de type
+    ...tseslint.configs.recommended.map((config) => ({
+        ...config,
+        files: ["**/*.js"],
+    })),
+
     // TypeScript (type-checked). Le consumer doit fournir parserOptions.project.
-    ...tseslint.configs.recommendedTypeChecked,
+    ...tseslint.configs.recommendedTypeChecked.map((config) => ({
+        ...config,
+        files: ["**/*.{ts,tsx}"],
+    })),
 
     // Soft-mode (transforme error -> warn en dev si plugin activé)
     { plugins: { "only-warn": onlyWarn } },


### PR DESCRIPTION
## Résumé
- Encapsulation des règles TypeScript vérifiées dans un bloc ciblant les fichiers TS
- Application d’un jeu de règles TypeScript sans infos de type pour les fichiers JS

## Test
- `yarn lint` *(échec : `yarn` introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a59de2c83248574c30c85ba9803