### PR TITLE
fix: remove file extensions from backend imports

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,5 +1,5 @@
 import { defineBackend } from "@aws-amplify/backend";
-import { auth } from "./auth/resource.js";
-import { data } from "./data/resource.js";
+import { auth } from "./auth/resource";
+import { data } from "./data/resource";
 import { PubliqueStorage } from "./storage/resource";
 defineBackend({ PubliqueStorage, auth, data });


### PR DESCRIPTION
## Summary
- remove `.js` extensions from auth and data imports in backend

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68bc93af39488324bb5b2c86dd51ce91