### PR TITLE
Suppression des extensions .js dans les exports de services

### DIFF
--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./amplify/setup.js";
-export * from "./amplify/useAmplifyReady.js";
+export * from "./amplify/setup";
+export * from "./amplify/useAmplifyReady";


### PR DESCRIPTION
## Résumé
- retire les suffixes `.js` des reexports `setup` et `useAmplifyReady`

## Tests
- `yarn tsc:packages` (échoue : Relative import paths need explicit file extensions)


------
https://chatgpt.com/codex/tasks/task_e_68bc938725ec8324abb1e500af2f14bf