### PR TITLE
Suppression des extensions .js dans les réexportations d'authentification AWS

### DIFF
--- a/packages/ui/src/auth/aws-authenticator/index.ts
+++ b/packages/ui/src/auth/aws-authenticator/index.ts
@@ -1,2 +1,2 @@
-export { configureI18n } from "./i18n.js";
-export { formFields, formFieldsAll } from "./forms.js";
+export { configureI18n } from "./i18n";
+export { formFields, formFieldsAll } from "./forms";


### PR DESCRIPTION
## Résumé
- remplace les importations `./i18n.js` et `./forms.js` par des chemins sans extension

## Tests
- `npx tsc --noEmit packages/ui/src/auth/aws-authenticator/index.ts`
- `npx eslint packages/ui/src/auth/aws-authenticator/index.ts`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68bc937b7c6c8324a49c1adf85a4d40f