### PR TITLE
Corriger l'export d'AuthProvider

### DIFF
--- a/packages/ui/src/auth/index.ts
+++ b/packages/ui/src/auth/index.ts
@@ -1,7 +1,7 @@
-export { AuthProvider } from "./auth/aws-authenticator/AuthProvider";
-export { default as Authentication } from "./auth/aws-authenticator/Authentication";
-export { default as AuthGuard } from "./auth/AuthGuard";
-export { RequireLoginButton } from "./auth/RequireLoginButton";
+export { default as AuthProvider } from "./aws-authenticator/auth-provider";
+export { default as Authentication } from "./aws-authenticator/Authentication";
+export { default as AuthGuard } from "./AuthGuard";
+export { RequireLoginButton } from "./RequireLoginButton";
 
 // déjà existants
-export { configureI18n, formFields } from "./auth/aws-authenticator";
+export { configureI18n, formFields } from "./aws-authenticator";


### PR DESCRIPTION
## Résumé
- corrige l'export d'AuthProvider vers `aws-authenticator/auth-provider`
- met à jour les autres réexportations avec des chemins relatifs valides

## Tests
- `npx eslint packages/ui/src/auth/index.ts`
- `npx tsc -p packages/ui/tsconfig.json --noEmit` *(échoue: modules manquants)*

------
https://chatgpt.com/codex/tasks/task_e_68bc936a830c8324a3f9e64260daf708