### PR TITLE
refactor: unify imports/exports (no .ts/.tsx/.js/.jsx) across monorepo + stable barrels + exports/typesVersions

### DIFF
--- a/apps/web/src/auth/providers/auth-provider.tsx
+++ b/apps/web/src/auth/providers/auth-provider.tsx
@@ -1,8 +1,8 @@
 // app/auth-provider.tsx
 "use client";
 
-import "@packages/services/amplify/setup"; // déclenche configure() au chargement du module
-import { useAmplifyReady } from "@packages/services/amplify/useAmplifyReady";
+import "@packages/services/amplify"; // déclenche configure() au chargement du module
+import { useAmplifyReady } from "@packages/services/amplify";
 import { Authenticator } from "@aws-amplify/ui-react";
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {

--- a/apps/web/src/entities/core/services/amplifyClient.ts
+++ b/apps/web/src/entities/core/services/amplifyClient.ts
@@ -1,5 +1,5 @@
 // src/entities/core/services/amplifyClient.ts
-import "@packages/services/amplify/setup";
+import "@packages/services/amplify";
 import { generateClient } from "aws-amplify/data";
 import type { Schema } from "@amplify/data/resource";
 

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -3,9 +3,18 @@
     "version": "0.1.0",
     "private": true,
     "type": "module",
-    "main": "src/index.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
-        ".": "./src/index.ts"
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "*": ["src/*"]
+        }
     },
     "scripts": {
         "build": "tsc --build",

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -5,7 +5,10 @@
         "outDir": "dist",
         "composite": true,
         "declaration": true,
-        "tsBuildInfoFile": "./dist/.tsbuildinfo"
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "tsBuildInfoFile": "./dist/.tsbuildinfo",
+        "skipLibCheck": true
     },
     "include": ["src"],
     "references": [{ "path": "../types" }]

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -4,15 +4,21 @@
     "private": true,
     "type": "module",
     "main": "dist/index.js",
-    "types": "src/index.d.ts",
+    "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "types": "./src/index.d.ts",
+            "types": "./dist/index.d.ts",
             "default": "./dist/index.js"
         },
-        "./amplify/*": {
-            "types": "./src/amplify/*.d.ts",
-            "default": "./dist/amplify/*.js"
+        "./amplify": {
+            "types": "./dist/amplify/index.d.ts",
+            "default": "./dist/amplify/index.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "amplify": ["src/amplify/index.ts"],
+            "*": ["src/*"]
         }
     },
     "scripts": {

--- a/packages/services/src/adapters/amplify/auth-client/Authentication.tsx
+++ b/packages/services/src/adapters/amplify/auth-client/Authentication.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { Authenticator, View, Heading, useTheme } from "@aws-amplify/ui-react";
 import "@aws-amplify/ui-react/styles.css";
-import { configureI18n, formFields } from "./index.js";
+import { configureI18n, formFields } from "./index";
 
 // import "@assets/styles/amplify/authenticator.scss";
 import { signUp } from "aws-amplify/auth";

--- a/packages/services/src/adapters/amplify/auth-client/index.ts
+++ b/packages/services/src/adapters/amplify/auth-client/index.ts
@@ -1,3 +1,3 @@
-export { default as Authentication } from "./Authentication.tsx";
-export { configureI18n } from "./i18n.ts";
-export { formFields, formFieldsAll } from "./forms.ts";
+export { default as Authentication } from "./Authentication";
+export { configureI18n } from "./i18n";
+export { formFields, formFieldsAll } from "./forms";

--- a/packages/services/src/adapters/index.ts
+++ b/packages/services/src/adapters/index.ts
@@ -1,1 +1,1 @@
-export * from "./amplify/auth-client/index.ts";
+export * from "./amplify/auth-client";

--- a/packages/services/src/amplify/index.ts
+++ b/packages/services/src/amplify/index.ts
@@ -1,0 +1,2 @@
+export * from "./setup";
+export * from "./useAmplifyReady";

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,3 +1,2 @@
 export * from "./userName";
-export * from "./setup";
-export * from "./useAmplifyReady";
+export * from "./amplify";

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -7,9 +7,8 @@
         "declaration": true,
         "jsx": "react-jsx",
         "emitDeclarationOnly": true,
-        // "allowImportingTsExtensions": true,
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
         "tsBuildInfoFile": "./dist/.tsbuildinfo",
         "skipLibCheck": true
     },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,9 +3,18 @@
     "version": "0.1.0",
     "private": true,
     "type": "module",
-    "main": "src/index.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
-        ".": "./src/index.ts"
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "*": ["src/*"]
+        }
     },
     "scripts": {
         "build": "tsc --build",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -5,7 +5,10 @@
         "outDir": "dist",
         "composite": true,
         "declaration": true,
-        "tsBuildInfoFile": "./dist/.tsbuildinfo"
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "tsBuildInfoFile": "./dist/.tsbuildinfo",
+        "skipLibCheck": true
     },
     "include": ["src"]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,9 +3,23 @@
     "version": "0.1.0",
     "private": true,
     "type": "module",
-    "main": "src/index.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
-        ".": "./src/index.ts"
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./auth": {
+            "types": "./dist/auth/index.d.ts",
+            "default": "./dist/auth/index.js"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "auth": ["src/auth/index.ts"],
+            "*": ["src/*"]
+        }
     },
     "scripts": {
         "build": "tsc --build",

--- a/packages/ui/src/auth/RequireLoginButton.tsx
+++ b/packages/ui/src/auth/RequireLoginButton.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import { useRouter } from "next/navigation";
 import { useAuthenticator } from "@aws-amplify/ui-react";
-import { goToLoginWithReturn } from "./goToLoginWithReturn.ts";
+import { goToLoginWithReturn } from "./goToLoginWithReturn";
 
 type Props = {
     children: React.ReactNode;

--- a/packages/ui/src/auth/index.ts
+++ b/packages/ui/src/auth/index.ts
@@ -1,2 +1,2 @@
-export { default as AuthGuard } from "./AuthGuard.tsx";
-export { RequireLoginButton } from "./RequireLoginButton.tsx";
+export { default as AuthGuard } from "./AuthGuard";
+export { RequireLoginButton } from "./RequireLoginButton";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./MarkdownViewer.tsx";
-export * from "./auth/index.ts";
+export * from "./MarkdownViewer";
+export * from "./auth";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -7,9 +7,8 @@
         "declaration": true,
         "jsx": "react-jsx",
         "emitDeclarationOnly": true,
-        "allowImportingTsExtensions": true,
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
         "tsBuildInfoFile": "./dist/.tsbuildinfo",
         "baseUrl": ".",
         "paths": {


### PR DESCRIPTION
## Summary
- enlever les extensions de chemins relatifs et introduire des barrels stables
- exposer les modules compilés via exports/typesVersions
- harmoniser les tsconfig des packages

## Testing
- `yarn exec tsc --build packages/types packages/domain packages/services packages/ui --verbose`
- `yarn --cwd apps/web build`
- `yarn workspace web lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd72dce48c832494c40a5ff9122e34