### PR TITLE
ci: bootstrap corepack before setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Bootstrap Corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@4.9.4 --activate
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- add an explicit corepack bootstrap run before invoking setup-node in the CI workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c93a2a7e5083248b895631e1d21d35