### PR TITLE
Corrige la configuration ESLint interne

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,7 +9,13 @@
         "test": "vitest run --passWithNoTests"
     },
     "devDependencies": {
-        "eslint-plugin-import": "^2.32.0"
+        "@eslint/js": "9.35.0",
+        "eslint-config-prettier": "10.1.1",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-react": "7.37.5",
+        "eslint-plugin-react-hooks": "5.2.0",
+        "globals": "16.3.0",
+        "typescript-eslint": "8.42.0"
     },
     "exports": {
         "./base": "./base.js",

--- a/packages/eslint-config/react-internal.js
+++ b/packages/eslint-config/react-internal.js
@@ -1,4 +1,5 @@
 import eslintConfigPrettier from "eslint-config-prettier";
+import pluginImport from "eslint-plugin-import";
 import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginReact from "eslint-plugin-react";
 import globals from "globals";
@@ -16,8 +17,14 @@ export const config = [
 
     // Hooks
     {
-        plugins: { "react-hooks": pluginReactHooks },
-        settings: { react: { version: "detect" } },
+        plugins: {
+            "react-hooks": pluginReactHooks,
+            import: pluginImport,
+        },
+        settings: {
+            react: { version: "detect" },
+            "import/core-modules": ["typescript-eslint"],
+        },
         rules: {
             ...pluginReactHooks.configs.recommended.rules,
             "react/react-in-jsx-scope": "off",
@@ -26,19 +33,23 @@ export const config = [
 
             // miroirs d’erreurs tsc pour tes alias/paths
             "import/no-unresolved": "error",
-
-            // ↓ Bruit TS côté UI (ne change pas les règles Next)
-            "@typescript-eslint/no-unsafe-call": "warn",
-            "@typescript-eslint/no-unsafe-member-access": "warn",
-            "@typescript-eslint/no-unsafe-assignment": "warn",
-            "@typescript-eslint/no-unsafe-return": "warn",
-            "@typescript-eslint/no-redundant-type-constituents": "warn",
         },
         languageOptions: {
             globals: {
                 ...globals.browser,
                 ...globals.serviceworker,
             },
+        },
+    },
+    {
+        files: ["**/*.{ts,tsx,cts,mts}"],
+        rules: {
+            // ↓ Bruit TS côté UI (ne change pas les règles Next)
+            "@typescript-eslint/no-unsafe-call": "warn",
+            "@typescript-eslint/no-unsafe-member-access": "warn",
+            "@typescript-eslint/no-unsafe-assignment": "warn",
+            "@typescript-eslint/no-unsafe-return": "warn",
+            "@typescript-eslint/no-redundant-type-constituents": "warn",
         },
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7835,7 +7835,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@packages/eslint-config@workspace:packages/eslint-config"
   dependencies:
+    "@eslint/js": "npm:9.35.0"
+    eslint-config-prettier: "npm:10.1.1"
     eslint-plugin-import: "npm:^2.32.0"
+    eslint-plugin-react: "npm:7.37.5"
+    eslint-plugin-react-hooks: "npm:5.2.0"
+    globals: "npm:16.3.0"
+    typescript-eslint: "npm:8.42.0"
   peerDependencies:
     "@eslint/js": ">=9.34.0 <10"
     "@next/eslint-plugin-next": ">=15.0.0 <16"


### PR DESCRIPTION
## Résumé
* ajoute toutes les dépendances de développement nécessaires au package `@packages/eslint-config` pour que les imports utilisés par la config soient résolus sans erreur
* enregistre explicitement `eslint-plugin-import`, configure la détection de `typescript-eslint` comme module interne et limite les règles `@typescript-eslint` aux fichiers TypeScript dans `react-internal.js`

## Tests
* `yarn tsc --noEmit`
* `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68c93e87a8288324aa9bf3a0369260a3